### PR TITLE
Add revision number to window title

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
+GIT_VERSION := $(shell git describe --abbrev=4 --dirty --always)
+
 CXX=g++
-CFLAGS=-W -Wall -Wextra -ansi -pedantic -s -O2 -DTIXML_USE_STL -DGL_GLEXT_PROTOTYPES $(INCLUDE)
+CFLAGS=-W -Wall -Wextra -ansi -pedantic -s -O2 -DTIXML_USE_STL -DGL_GLEXT_PROTOTYPES -DGIT_VERSION=\"$(GIT_VERSION)\" $(INCLUDE)
 INCLUDE=-Isrc/entities -Isrc/loadable -Isrc/models -Isrc/ -Isrc/utils -Isrc/geom -Ilib/ -Ilib/utils/ -Ilib/TmxParser/ -Ilib/TmxParser/base64/
 LDFLAGS=-lsfml-system -lsfml-graphics -lsfml-window -ltinyxml -lGL -lglut -lGLU -lz -llua5.2
 EXEC=bin/jlug
 SRC= $(wildcard src/geom/*.cpp) $(wildcard src/entities/*.cpp) $(wildcard src/loadable/*.cpp) $(wildcard src/models/*.cpp) $(wildcard src/utils/*.cpp) $(wildcard src/*.cpp) $(wildcard lib/*.cpp) $(wildcard lib/utils/*.cpp) $(wildcard lib/TmxParser/*.cpp) $(wildcard lib/TmxParser/base64/*.cpp)
 OBJ= $(SRC:.cpp=.o)
+
 
 build: $(EXEC)
 

--- a/src/example.cpp
+++ b/src/example.cpp
@@ -7,8 +7,11 @@
 #include <iostream>
 
 void game(void)
- {
-    jlug::Window win(800, 600, "hello world ! ");
+{
+    std::ostringstream title;
+    title << "jLug - " << GIT_VERSION;
+
+    jlug::Window win(800, 600, title.str());
     jlug::Input input = win.getInput();
 
     jlug::Map map("../res/maps/map.tmx", win, input);
@@ -35,17 +38,17 @@ void game(void)
 
         //first.move(map);
 
-        //player.move(map); // hi ! 
+        //player.move(map); // hi !
 
         map.moveCharacters();
         for (unsigned int k(0);k<map.getDepth();++k)
             map.displayLayer(win, k);
         map.displayCharacters(win);
-        
+
 
 
         //player.displayUsername(win);
-        
+
         win.flip();
     }
     win.close();


### PR DESCRIPTION
I've add git revision number in the window title.
It can help debugging, and is better than "hello world" imo.

Could you configure your editor so it removes trailing whitespaces ?
